### PR TITLE
Fix Mopidy 3.x compatibility issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,16 @@ Known issues
 =========
 
 - Mopidy proxy settings are ignored by the extension.
-- Search is not implemented.
 
 
 Changelog
 =========
+
+v0.5.1 (2020-03-14)
+-------------------
+
+- Fixed Mopidy 3.x compatibility issue.
+
 
 v0.5.0 (2019-02-01)
 -------------------

--- a/mopidy_cd/__init__.py
+++ b/mopidy_cd/__init__.py
@@ -5,7 +5,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '0.5'
+__version__ = '0.5.1'
 
 
 class Extension(ext.Extension):

--- a/mopidy_cd/backend.py
+++ b/mopidy_cd/backend.py
@@ -117,7 +117,6 @@ class CdLibrary(backend.LibraryProvider):
             name=disc.title,
             date=disc.year,
             artists={CdLibrary._make_artist(ar) for ar in disc.artists},
-            images=disc.images,
             num_discs=disc.discs,
             num_tracks=len(disc.tracks)
         )

--- a/mopidy_cd/cdrom.py
+++ b/mopidy_cd/cdrom.py
@@ -128,7 +128,7 @@ class CdRom(object):
     @staticmethod
     def _extract_tracks(discid, medium_list=()):
         def match_by_discid(medium):
-            if medium['format'].lower() != 'cd':
+            if medium.get('format', '').lower() != 'cd':
                 return False
             return any(disc['id'] == discid.id for disc in medium['disc-list'])
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'setuptools',
-        'Mopidy >= 1.0',
+        'Mopidy >= 2.0',
         'Pykka >= 1.1',
         'musicbrainzngs == 0.6',
     ],


### PR DESCRIPTION
Mopidy 3.0 removed deprecated `mopidy.models.Album.images` field.